### PR TITLE
mock api response for integration test

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -17,14 +17,20 @@ export function initApp({
 
   app.use(express.json())
 
-  app.use('/quote', quoteRouter({ jwtAuthMiddleware, clientAuthMiddleware }))
-  app.use('/kyc', kycRouter({ jwtAuthMiddleware, clientAuthMiddleware }))
   app.use(
-    '/accounts',
+    '/:providerName?/quote',
+    quoteRouter({ jwtAuthMiddleware, clientAuthMiddleware }),
+  )
+  app.use(
+    '/:providerName?/kyc',
+    kycRouter({ jwtAuthMiddleware, clientAuthMiddleware }),
+  )
+  app.use(
+    '/:providerName?/accounts',
     accountsRouter({ jwtAuthMiddleware, clientAuthMiddleware }),
   )
   app.use(
-    '/transfer',
+    '/:providerName?/transfer',
     transferRouter({ jwtAuthMiddleware, clientAuthMiddleware }),
   )
 

--- a/src/middleware/extractProvider.ts
+++ b/src/middleware/extractProvider.ts
@@ -1,0 +1,16 @@
+import express from 'express'
+import { availableProviders } from '../mocks/providerResponses'
+
+export default function extractProvider(
+  req: express.Request,
+  _res: express.Response,
+  next: express.NextFunction,
+): any {
+  const [providerName] = req.baseUrl.split('/').slice(1)
+
+  _res.locals.provider = availableProviders.includes(providerName)
+    ? providerName
+    : 'default'
+
+  next()
+}

--- a/src/mocks/providerResponses/default.ts
+++ b/src/mocks/providerResponses/default.ts
@@ -1,0 +1,117 @@
+import {
+  QuoteResponse,
+  FiatType,
+  CryptoType,
+  KycSchema,
+  FiatAccountSchema,
+  KycStatus,
+  GetFiatAccountsResponse,
+  FiatAccountType,
+  ObfuscatedFiatAccountData,
+  TransferStatusResponse,
+  TransferStatus,
+  TransferType,
+  TransferResponse,
+} from '@fiatconnect/fiatconnect-types'
+
+export default {
+  quoteIn: {
+    quote: {
+      fiatType: FiatType.USD,
+      cryptoType: CryptoType.cUSD,
+      fiatAmount: '100',
+      cryptoAmount: '100',
+    },
+    kyc: {
+      kycRequired: true,
+      kycSchemas: [KycSchema.PersonalDataAndDocuments],
+    },
+    fiatAccount: {
+      MockCheckingAccount: {
+        fiatAccountSchemas: [FiatAccountSchema.MockCheckingAccount],
+      },
+      MockDebitCard: {
+        fiatAccountSchemas: [FiatAccountSchema.MockCheckingAccount],
+      },
+      MockCreditCard: {
+        fiatAccountSchemas: [FiatAccountSchema.MockCheckingAccount],
+      },
+    },
+  },
+  quoteOut: {
+    quote: {
+      fiatType: FiatType.USD,
+      cryptoType: CryptoType.cUSD,
+      fiatAmount: '100',
+      cryptoAmount: '100',
+    },
+    kyc: {
+      kycRequired: true,
+      kycSchemas: [KycSchema.PersonalDataAndDocuments],
+    },
+    fiatAccount: {
+      MockCheckingAccount: {
+        fiatAccountSchemas: [FiatAccountSchema.MockCheckingAccount],
+      },
+      MockDebitCard: {
+        fiatAccountSchemas: [FiatAccountSchema.MockCheckingAccount],
+      },
+      MockCreditCard: {
+        fiatAccountSchemas: [FiatAccountSchema.MockCheckingAccount],
+      },
+    },
+  },
+  postKycData: {
+    kycStatus: KycStatus.Approved,
+  },
+  getKycStatus: {
+    status: KycStatus.Approved,
+  },
+  postAccountSchema: {
+    fiatAccountId: '12345',
+    name: 'Chase checking account',
+    institution: 'Chase Bank',
+    fiatAccountType: FiatAccountType.MockCheckingAccount,
+  },
+  getAccounts: {
+    MockCheckingAccount: [
+      {
+        fiatAccountId: '12345',
+        name: 'Chase checking account',
+        institution: 'Chase Bank',
+        fiatAccountType: FiatAccountType.MockCheckingAccount,
+      },
+    ],
+    MockDebitCard: [
+      {
+        fiatAccountId: '12345',
+        name: 'Chase checking account',
+        institution: 'Chase Bank',
+        fiatAccountType: FiatAccountType.MockCheckingAccount,
+      },
+    ],
+    MockCreditCard: [
+      {
+        fiatAccountId: '12345',
+        name: 'Chase checking account',
+        institution: 'Chase Bank',
+        fiatAccountType: FiatAccountType.MockCheckingAccount,
+      },
+    ],
+  },
+  postTransfer: {
+    transferId: '9589gh57jd3',
+    transferStatus: TransferStatus.TransferComplete,
+    transferAddress: '0x57848hf478t784h',
+  },
+  getTransferStatus: {
+    status: TransferStatus.TransferComplete,
+    transferType: TransferType.TransferOut,
+    fiatType: FiatType.USD,
+    cryptoType: CryptoType.cUSD,
+    amountProvided: '100',
+    amountReceived: '100',
+    fee: '0',
+    fiatAccountId: '12345',
+  },
+}

--- a/src/mocks/providerResponses/index.ts
+++ b/src/mocks/providerResponses/index.ts
@@ -1,0 +1,35 @@
+// import defaultResponse from './default.json'
+import {
+  QuoteResponse,
+  FiatType,
+  CryptoType,
+  KycSchema,
+  FiatAccountSchema,
+  KycStatus,
+  GetFiatAccountsResponse,
+  FiatAccountType,
+  ObfuscatedFiatAccountData,
+  TransferStatusResponse,
+  TransferStatus,
+  TransferType,
+  TransferResponse,
+} from '@fiatconnect/fiatconnect-types'
+import defaultResponse from './default'
+
+interface ProviderResponse {
+  quoteIn: QuoteResponse
+  quoteOut: QuoteResponse
+  postKycData: { kycStatus: KycStatus }
+  getKycStatus: { status: KycStatus }
+  postAccountSchema: ObfuscatedFiatAccountData
+  getAccounts: GetFiatAccountsResponse
+  postTransfer: TransferResponse
+  getTransferStatus: TransferStatusResponse
+}
+
+export const availableProviders = ['default']
+
+const providerResponses: Record<string, ProviderResponse> = {
+  default: defaultResponse,
+}
+export { providerResponses }

--- a/src/routes/quote.ts
+++ b/src/routes/quote.ts
@@ -1,11 +1,9 @@
 import express from 'express'
 import { asyncRoute } from './async-route'
 import { validateSchema } from '../schema/'
-import {
-  QuoteRequestQuery,
-  NotImplementedError,
-  JwtAuthorizationMiddleware,
-} from '../types'
+import { QuoteRequestQuery, JwtAuthorizationMiddleware } from '../types'
+import { providerResponses } from '../mocks/providerResponses/index'
+import extractProvider from '../middleware/extractProvider'
 
 export function quoteRouter({
   jwtAuthMiddleware,
@@ -29,30 +27,37 @@ export function quoteRouter({
         req.query,
         'QuoteRequestQuerySchema',
       )
+
       next()
     },
   )
 
   router.get(
     '/in',
+    extractProvider,
     asyncRoute(
       async (
         _req: express.Request<{}, {}, {}, QuoteRequestQuery>,
         _res: express.Response,
       ) => {
-        throw new NotImplementedError('GET /quote/in not implemented')
+        const providerResponse = providerResponses[_res.locals.provider]
+
+        _res.status(200).json(providerResponse.quoteIn)
       },
     ),
   )
 
   router.get(
     '/out',
+    extractProvider,
     asyncRoute(
       async (
         _req: express.Request<{}, {}, {}, QuoteRequestQuery>,
         _res: express.Response,
       ) => {
-        throw new NotImplementedError('GET /quote/out not implemented')
+        const providerResponse = providerResponses[_res.locals.provider]
+
+        _res.status(200).json(providerResponse.quoteOut)
       },
     ),
   )

--- a/src/routes/transfer.ts
+++ b/src/routes/transfer.ts
@@ -4,9 +4,10 @@ import { validateSchema } from '../schema/'
 import {
   TransferRequestBody,
   TransferStatusRequestParams,
-  NotImplementedError,
   JwtAuthorizationMiddleware,
 } from '../types'
+import extractProvider from '../middleware/extractProvider'
+import { providerResponses } from '../mocks/providerResponses'
 
 export function transferRouter({
   jwtAuthMiddleware,
@@ -46,12 +47,15 @@ export function transferRouter({
     jwtAuthMiddleware.expirationRequired,
     clientAuthMiddleware,
     transferRequestBodyValidator,
+    extractProvider,
     asyncRoute(
       async (
         _req: express.Request<{}, {}, TransferRequestBody>,
         _res: express.Response,
       ) => {
-        throw new NotImplementedError('POST /transfer/in not implemented')
+        const providerResponse = providerResponses[_res.locals.provider]
+
+        _res.status(200).json(providerResponse.postTransfer)
       },
     ),
   )
@@ -61,12 +65,15 @@ export function transferRouter({
     jwtAuthMiddleware.expirationRequired,
     clientAuthMiddleware,
     transferRequestBodyValidator,
+    extractProvider,
     asyncRoute(
       async (
         _req: express.Request<{}, {}, TransferRequestBody>,
         _res: express.Response,
       ) => {
-        throw new NotImplementedError('POST /transfer/out not implemented')
+        const providerResponse = providerResponses[_res.locals.provider]
+
+        _res.status(200).json(providerResponse.postTransfer)
       },
     ),
   )
@@ -76,14 +83,15 @@ export function transferRouter({
     jwtAuthMiddleware.expirationOptional,
     clientAuthMiddleware,
     transferStatusRequestParamsValidator,
+    extractProvider,
     asyncRoute(
       async (
         _req: express.Request<TransferStatusRequestParams>,
         _res: express.Response,
       ) => {
-        throw new NotImplementedError(
-          'GET /transfer/:transferId/status not implemented',
-        )
+        const providerResponse = providerResponses[_res.locals.provider]
+
+        _res.status(200).json(providerResponse.getTransferStatus)
       },
     ),
   )


### PR DESCRIPTION
Fixes: #4 
NOTE: This PR is only for review purpose, I do not intend to commit to this repo. I thought it might be easier to review if I open the PR here 

Something interesting here is probably the extractProvider middleware, it's implemented to enable mocking responses from different providers.  eg. GET `/finclusive/quote/in` would look for a a file names `finclusive.ts` from `mocks/providerResponses`. If no provider name is supplied to the request url,  it would return the default response

Todo:
- some testing
- auth