### PR TITLE
chore!: batched updates from spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@celo/utils": "^1.5.2",
-    "@fiatconnect/fiatconnect-types": "^2.0.0",
+    "@fiatconnect/fiatconnect-types": "^3.0.0",
     "@types/express": "^4.17.13",
     "@types/node": "^17.0.21",
     "@types/yargs": "^17.0.8",

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -58,6 +58,7 @@ export function accountsRouter({
         switch (req.params.fiatAccountSchema) {
           case FiatAccountSchema.AccountNumber:
             validateSchema<AccountNumber>(req.body, 'AccountNumberSchema')
+            break
           default:
             throw new Error(
               `Non-existent fiat account schema "${req.params.fiatAccountSchema}"`,

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -5,7 +5,7 @@ import {
   AddFiatAccountRequestParams,
   DeleteFiatAccountRequestParams,
   FiatAccountSchema,
-  MockCheckingAccount,
+  AccountNumber,
   NotImplementedError,
   JwtAuthorizationMiddleware,
 } from '../types'
@@ -56,11 +56,8 @@ export function accountsRouter({
       ) => {
         // Delegate to type-specific handlers after validation provides type guards
         switch (req.params.fiatAccountSchema) {
-          case FiatAccountSchema.MockCheckingAccount:
-            validateSchema<MockCheckingAccount>(
-              req.body,
-              'MockCheckingAccountSchema',
-            )
+          case FiatAccountSchema.AccountNumber:
+            validateSchema<AccountNumber>(req.body, 'AccountNumberSchema')
           default:
             throw new Error(
               `Non-existent fiat account schema "${req.params.fiatAccountSchema}"`,

--- a/src/schema/account-number.ts
+++ b/src/schema/account-number.ts
@@ -1,32 +1,32 @@
 import { JSONSchemaType } from 'ajv'
-import { MockCheckingAccount, FiatType } from '../types'
+import { AccountNumber, FiatAccountType } from '../types'
 
-export const mockCheckingAccountSchema: JSONSchemaType<MockCheckingAccount> = {
-  $id: 'MockCheckingAccountSchema',
+export const accountNumberSchema: JSONSchemaType<AccountNumber> = {
+  $id: 'AccountNumberSchema',
   type: 'object',
   properties: {
-    bankName: {
+    institutionName: {
       type: 'string',
     },
     accountName: {
       type: 'string',
     },
-    fiatType: {
+    fiatAccountType: {
       type: 'string',
-      enum: Object.values(FiatType),
+      enum: [FiatAccountType.BankAccount],
     },
     accountNumber: {
       type: 'string',
     },
-    routingNumber: {
+    country: {
       type: 'string',
     },
   },
   required: [
-    'bankName',
+    'institutionName',
     'accountName',
-    'fiatType',
     'accountNumber',
-    'routingNumber',
+    'country',
+    'fiatAccountType',
   ],
 }

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -6,7 +6,7 @@ import { kycRequestParamsSchema } from './kyc-request-params'
 import { personalDataAndDocumentsKycSchema } from './personal-data-and-documents-kyc'
 import { addFiatAccountRequestParamsSchema } from './add-fiat-account-request-params'
 import { deleteFiatAccountRequestParamsSchema } from './delete-fiat-account-request-params'
-import { accountNumberSchema } from './mock-checking-account'
+import { accountNumberSchema } from './account-number'
 import { transferRequestBodySchema } from './transfer-request-body'
 import { transferStatusRequestParamsSchema } from './transfer-status-request-params'
 

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -6,7 +6,7 @@ import { kycRequestParamsSchema } from './kyc-request-params'
 import { personalDataAndDocumentsKycSchema } from './personal-data-and-documents-kyc'
 import { addFiatAccountRequestParamsSchema } from './add-fiat-account-request-params'
 import { deleteFiatAccountRequestParamsSchema } from './delete-fiat-account-request-params'
-import { mockCheckingAccountSchema } from './mock-checking-account'
+import { accountNumberSchema } from './mock-checking-account'
 import { transferRequestBodySchema } from './transfer-request-body'
 import { transferStatusRequestParamsSchema } from './transfer-status-request-params'
 
@@ -17,7 +17,7 @@ const ajv = new Ajv({
     personalDataAndDocumentsKycSchema,
     addFiatAccountRequestParamsSchema,
     deleteFiatAccountRequestParamsSchema,
-    mockCheckingAccountSchema,
+    accountNumberSchema,
     transferRequestBodySchema,
     transferStatusRequestParamsSchema,
   ],

--- a/src/schema/transfer-request-body.ts
+++ b/src/schema/transfer-request-body.ts
@@ -19,6 +19,9 @@ export const transferRequestBodySchema: JSONSchemaType<TransferRequestBody> = {
     fiatAccountId: {
       type: 'string',
     },
+    quoteId: {
+      type: 'string',
+    },
   },
-  required: ['fiatType', 'cryptoType', 'amount', 'fiatAccountId'],
+  required: ['fiatType', 'cryptoType', 'amount', 'fiatAccountId', 'quoteId'],
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,9 +9,10 @@ import {
   AddFiatAccountRequestParams,
   DeleteFiatAccountRequestParams,
   FiatAccountSchema,
-  MockCheckingAccount,
+  AccountNumber,
   FiatType,
   CryptoType,
+  FiatAccountType,
 } from '@fiatconnect/fiatconnect-types'
 import express from 'express'
 
@@ -25,8 +26,9 @@ export {
   AddFiatAccountRequestParams,
   DeleteFiatAccountRequestParams,
   FiatAccountSchema,
-  MockCheckingAccount,
+  AccountNumber,
   FiatType,
+  FiatAccountType,
   CryptoType,
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -713,10 +713,10 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
-"@fiatconnect/fiatconnect-types@^2.0.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-2.1.0.tgz#29ecb871d4a030e50664180326fedc771edd203c"
-  integrity sha512-nqGyOAPPr6hdzfDsbcwsRQ157H0IGkDPagiXEmCNY8zxjfK6mq9Yc+Z62347LzPO3niv2b/r1soE85UJ/JlVYw==
+"@fiatconnect/fiatconnect-types@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-3.0.0.tgz#684b8f5c6beefb98db3a2a3c41066b976e099269"
+  integrity sha512-JMyAgkHNufqbo9roDmUpzhZH3UMbhyuLYYMI9kE1qQTtQMPVlPz9zHbS2syFz2Ymdjl7wzgIijph+QckYwwP8A==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"


### PR DESCRIPTION
updating to the latest specification (up thru 54138dd3a7bb1fa5f44d0564ac0b8e26d5d72f13 in [spec repo](https://github.com/fiatconnect/specification/commits/main))

BREAKING CHANGES:
- added quoteId as required parameter to transfer-request-body.ts
- removed MockCheckingAccount fiat account type

other updates:
- added cREAL crypto type
- replaced MockCheckingAccount with AccountNumber fiat account schema
- added quoteId to quote response type