### PR TITLE
chore: updates to match spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@celo/utils": "^1.5.2",
-    "@fiatconnect/fiatconnect-types": "^3.0.0",
+    "@fiatconnect/fiatconnect-types": "^3.1.0",
     "@types/express": "^4.17.13",
     "@types/node": "^17.0.21",
     "@types/yargs": "^17.0.8",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
 import express from 'express'
-import { JwtAuthorizationMiddleware } from './types'
+import {JwtAuthorizationMiddleware, NotImplementedError} from './types'
 import { quoteRouter } from './routes/quote'
 import { kycRouter } from './routes/kyc'
 import { accountsRouter } from './routes/accounts'
@@ -16,6 +16,12 @@ export function initApp({
   const app = express()
 
   app.use(express.json())
+
+  app.get('/clock', (_req, _res) => {
+    // NOTE: you *could* just use res.status(200).send({time: new Date().toISOFormat()}), BUT only if your server is single-node
+    //  (otherwise you need session affinity or some way of guaranteeing consistency of the current time between nodes)
+    throw new NotImplementedError()
+  })
 
   app.use('/quote', quoteRouter({ jwtAuthMiddleware, clientAuthMiddleware }))
   app.use('/kyc', kycRouter({ jwtAuthMiddleware, clientAuthMiddleware }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -714,9 +714,9 @@
     "@ethersproject/strings" "^5.5.0"
 
 "@fiatconnect/fiatconnect-types@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-3.0.0.tgz#684b8f5c6beefb98db3a2a3c41066b976e099269"
-  integrity sha512-JMyAgkHNufqbo9roDmUpzhZH3UMbhyuLYYMI9kE1qQTtQMPVlPz9zHbS2syFz2Ymdjl7wzgIijph+QckYwwP8A==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-3.1.0.tgz#092dbe1b43d020a4751a108a5af52ac6cd95f4a7"
+  integrity sha512-Q7y3O/+tE9ewOYWlZvSVmSMQkLn25C1fSN7qiZAbKJaXJctZ2HvSrwYAHgL+eNirw6yj6+ursJCUsXTpnYydBA==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -713,7 +713,7 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
-"@fiatconnect/fiatconnect-types@^3.0.0":
+"@fiatconnect/fiatconnect-types@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-3.1.0.tgz#092dbe1b43d020a4751a108a5af52ac6cd95f4a7"
   integrity sha512-Q7y3O/+tE9ewOYWlZvSVmSMQkLn25C1fSN7qiZAbKJaXJctZ2HvSrwYAHgL+eNirw6yj6+ursJCUsXTpnYydBA==


### PR DESCRIPTION
- /clock endpoint
- version bumped fiatconnect-types

auth is out of scope and /accounts is already plural, so this is all that's needed for https://github.com/valora-inc/wallet/issues/2359